### PR TITLE
User-Based Authentication Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ By default ForteApi will perform a browser fingerprint on the client via a non-b
 An Isomorphic usage example:
 
 ##### server.js
-``` js
-import ForteApi from 'forte-api'
+```js
+import createApi from 'forte-api'
 
 // a global to be injected in to your html markup
 CLIENT_GLOBALS = {
@@ -43,16 +43,16 @@ CLIENT_GLOBALS = {
         trunk: 'TRUNKID'
         branch: 'BRANCHID',
     },
-    BearerToken = null;
+    BearerToken: null
 }
 
 let creds = {
-  apiPrivateKey: 'PRIVATEKEY',
-  apiPublicKey: 'PUBLICKEY',
+  privateKey: 'PRIVATEKEY',
+  publicKey: 'PUBLICKEY',
 }
 
 // create a new api instance using secret keys
-let api = ForteApi(creds, CLIENT_GLOBALS.scope)
+let api = createApi(creds, CLIENT_GLOBALS.scope)
 
 // listen for authentication events to capture the token
 api.on('auth', (err, token) => {
@@ -71,19 +71,19 @@ app.get('*', function(req, res, next) => {
 ```
 
 ##### client.js
-``` js
-import ForteApi from 'forte-api'
+```js
+import createApi from 'forte-api'
 
 // presuming CLIENT_GLOBALS was injected in your markup by the server
 let creds = { bearerToken: CLIENT_GLOBALS.BearerToken }
 
-let api = ForteApi(creds, CLIENT_GLOBALS.scope)
+let api = createApi(creds, CLIENT_GLOBALS.scope)
 
 ReactDOM.render(<App api={api} />, document.getElementById('app'));
 ```
 
 ##### app.js
-``` js
+```js
 
 let results = api.composite
     .query({...})
@@ -101,11 +101,11 @@ let results = api.composite
 
 ### Constructor
 
-#### ForteApi(credentials, scope, [options])
+#### `createApi(credentials, scope, [options])`
 Creates an instance of the Forte Api.
 
-``` js
-import ForteApi from 'forte-api'
+```js
+import createApi from 'forte-api'
 
 let scope = {
   trunk: 'TRUNKID',
@@ -113,10 +113,10 @@ let scope = {
 }
 
 // defaults
-let api = ForteApi(credentials, scope);
+let api = createApi(credentials, scope);
 
 // override api options
-let api = ForteApi(credentials, scope, options);
+let api = createApi(credentials, scope, options);
 ```
 
 ###### args
@@ -146,12 +146,11 @@ All api requests require at least a `trunk` scope and most also require a `branc
 
 The [constructor](#constructor) requires a `scope.trunk` param, but for requests requiring `branch` scope you can also use `api.withBranch()`. This is particularly useful on the server side, where you may have non-branch api calls during bootstrapping, as well as branch scoped calls during individual page requests.
 
-```js
-
+```jsx
 var creds = {...}
 var scope = { trunk: 'TRUNKID' } // note the lack of a branch
 
-var api = ForteApi(creds, scope, opts)
+var api = createApi(creds, scope, opts)
 
 // use lifecycle middleware to resolve scope
 app.use(lifecycle(api))
@@ -176,14 +175,14 @@ The identifier of the `branch` that future request should be scoped to.
 
 ```js
 var scope = { trunk: 'TRUNKID' }
-var api = ForteApi(creds, scope).withBranch('BRANCHID')
+var api = createApi(creds, scope).withBranch('BRANCHID')
 
 ```
 
 Or the equivalent:
 ```js
 var scope = { trunk: 'TRUNKID', branch: 'BRANCHID' }
-var api = ForteApi(creds, scope)
+var api = createApi(creds, scope)
 ```
 
 #### api.getScope(): {object}
@@ -201,9 +200,9 @@ The branch ID of the scope. Since only `trunk` is required, it is possible for t
 #### api.on('auth', callback(err, token))
 When the api successfully creates a new Bearer Token session this method will be invoked with the new bearerToken value. If an error occured it will be returned via the err argument.
 
-``` js
-import ForteApi from 'forte-api'
-let api = ForteApi(credentials, organization, options);
+```js
+import createApi from 'forte-api'
+let api = createApi(credentials, organization, options);
 
 api.on('auth', (err, token) => {
     if(err) {
@@ -341,7 +340,7 @@ Writes events to the platform API.
 A json object containing one or more [supported events](#supported-analytics-events).
 
 
-``` js
+```js
 api.analytics.track({
     'pageview': {
         title: 'Hello World',
@@ -358,7 +357,7 @@ The title of the page.
 * `location: {string}`
 The full url of the page excluding the hash.
 
-``` js
+```js
 api.analytics.track({
     'pageview': {
         title: 'Hello World',

--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ import createApi from 'forte-api'
 // a global to be injected in to your html markup
 CLIENT_GLOBALS = {
     scope: {
-        trunk: 'TRUNKID'
-        branch: 'BRANCHID',
-    },
-    BearerToken: null
+        trunk: 'TRUNKID',
+        branch: 'BRANCHID'
+    }   
 }
 
 let creds = {
   privateKey: 'PRIVATEKEY',
-  publicKey: 'PUBLICKEY',
+  publicKey: 'PUBLICKEY'
 }
 
 // create a new api instance using secret keys
@@ -62,7 +61,7 @@ api.on('auth', (err, token) => {
     }
 
     console.log('Api auth success:', token)
-    CLIENT_GLOBALS.BearerToken = token
+    creds.bearerToken = token
 })
 
 app.get('*', function(req, res, next) => {

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,6 @@
 import crypto from 'crypto'
 import superagent from 'superagent'
+import InvalidArgumentError from './util'
 const debug = require('debug')('forte-api:client')
 
 const METHODS = ['get', 'post', 'put', 'patch', 'delete']
@@ -10,7 +11,7 @@ function authMiddleware(superagent, hostname, credentials) {
 
     if (credentials.bearerToken) {
       authHeader = `${credentials.bearerToken}`
-    } else {
+    } else if (credentials.privateKey) {
       const UTCTimestamp = Math.floor((new Date()).getTime() / 1000)
       const FQDN = hostname
       const checkSumData = [credentials.privateKey, credentials.publicKey, UTCTimestamp, FQDN].join(':')
@@ -20,6 +21,10 @@ function authMiddleware(superagent, hostname, credentials) {
       debug('hash %s', hash)
 
       authHeader = `Checksum ${[credentials.publicKey, UTCTimestamp, hash, FQDN].join(':')}`
+    } else if (credentials.email) {
+      return this
+    } else {
+      throw new InvalidArgumentError('No publicKey/privateKey or email/password credentials were provided.')
     }
 
     this.set('Authorization', authHeader)
@@ -59,8 +64,8 @@ class Client {
         request.end((err, res) => {
           if(err) { debug(`client.${method} error: %o`, err) }
 
-          // all succesful api responses have auth header <- NOT TRUE on token auth
-          // all succesful CHECKSUM api responses have auth header, keep the bearerToken if not passed
+          // all successful api responses have auth header <- NOT TRUE on token auth
+          // all successful CHECKSUM api responses have auth header, keep the bearerToken if not passed
           onAuth && onAuth(err, err ? null : (res.headers.authorization ? res.headers.authorization : credentials.bearerToken))
 
           err ? reject(err) : resolve(res)

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,9 @@ function forteApi(credentials, scope, options) {
       validateArgs('log', arguments)
       return client.post(ApiPaths.log, { data: { level, message, meta } })
     },
+    auth() {
+      return client.post(ApiPaths.auth, { data: { email: credentials.email, password: credentials.password }})
+    },
     experience: {
       session() {
         return client.get(ApiPaths.experience.session())
@@ -207,13 +210,23 @@ const validators = {
         return
       }
 
-      if(typeof credentials.privateKey !== 'string') {
-        throw new InvalidArgumentError('credentials.privateKey')
+      if(typeof credentials.email === 'string' && typeof credentials.privateKey === 'string') {
+        throw new InvalidArgumentError('only one of publicKey/privateKey or email/password combinations may be provided.')
       }
 
-      if(typeof credentials.publicKey !== 'string') {
-        throw new InvalidArgumentError('credentials.publicKey')
+      if(typeof credentials.privateKey === 'string') {
+        if(typeof credentials.publicKey !== 'string') {
+          throw new InvalidArgumentError('credentials.publicKey')
+        }
+        return
+      } else if(typeof credentials.email === 'string'){
+        if(typeof credentials.password !== 'string') {
+          throw new InvalidArgumentError('credentials.password')
+        }
+        return
       }
+
+      throw new InvalidArgumentError('credentials in the form of a publicKey/privateKey or email/password combination must be provided.')
     }
 
     function verifyScope(scope) {

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,7 @@ require('extend-error')
 
 export const ApiPaths = {
   log: '/developer/log',
+  auth: '/authenticate/credentials',
   experience: {
     session: function session() {
       return '/session/check';


### PR DESCRIPTION
This provides support for user-based authentication with `email` and `password` credentials, where either credentials with `publicKey/privateKey` _*or*_ `email/password` are supported when creating the API. `.on('auth', ...)` still functions properly, and clients must call `api.auth()` in order to authenticate. Example:

```js
import createApi from 'forte-api'
import os from 'os'

const scope = {
  hostname : os.hostname(),
  trunk    : trunkID,
}
const creds = {
  email    : 'some@body.com',
  password : 'mysupersecretpassword',
}

const api = createApi(creds, scope, {url: 'http://api.powerchord.io'})

api.on('auth', (err, token) => {
  if (err) {
    // ...
  }
  creds.bearerToken = token
})

api.auth().then(() => {
  // ...
})
```

Some of the documentation was also inaccurate and has been fixed to the best of my ability. Most of it was replacing `ForteApi` with `createApi`.