### PR TITLE
fix: only look up active orgs with experiences by hostname

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -21,7 +21,7 @@ export const ApiPaths = {
       return '/organizations/' + id;
     },
     getOneByHostname: function getOneByHostname(hostname) {
-      return '/organizations?hostname=' + hostname;
+      return '/organizations?status=active&hasExperience=true&hostname=' + hostname;
     }
   },
   locations: {


### PR DESCRIPTION
This fixes the organization lookup by hostname to exclude inactive orgs and ones without experiences.